### PR TITLE
[PF-106] Add workflow to automate the update of Rasa Pro image tag in docker compose file

### DIFF
--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -64,7 +64,7 @@ jobs:
           run: |
             if [ "$latest_tag" != ""No updates." ]; then
               echo "Image tag changed from $current_tag to $latest_tag"
-              sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro::$current_tag|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$latest_tag|" docker-compose.yml
+              sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$current_tag|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$latest_tag|" docker-compose.yml
               echo "image_tag_changed=true" >> $GITHUB_OUTPUT
             else
               echo "Image tag is already up-to-date."

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -60,15 +60,15 @@ jobs:
           if: (github.event_name == 'repository_dispatch' && steps.compare_versions.outputs.should_update == 'true') || github.event_name != 'repository_dispatch'
           run: |
             latest_tag=$(python scripts/update_rasa_pro_image_tag.py)
-            echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+            echo "LATEST_TAG=${latest_tag}" >> $GITHUB_ENV
 
         - name: Check if image tag changed
           id: check_image_tag
           if: steps.update_image_tag.outcome == 'success'
           run: |
-            if [ "$latest_tag" != "No updates." ]; then
-              echo "Image tag changed from $current_tag to $latest_tag"
-              sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$current_tag|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$latest_tag|" docker-compose.yml
+            if [ "$LATEST_TAG" != "No updates." ]; then
+              echo "Image tag changed from $CURRENT_RASA_PRO_VERSION to $LATEST_TAG"
+              sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$CURRENT_RASA_PRO_VERSION|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$LATEST_TAG|" docker-compose.yml
               echo "image_tag_changed=true" >> $GITHUB_OUTPUT
             else
               echo "Image tag is already up-to-date."

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -1,0 +1,103 @@
+name: update-rasa-pro-image-tag-version.yml
+on:
+    workflow_dispatch:
+    # push required only for testing purposes
+    # to be removed before merging
+    push:
+    repository_dispatch:
+      types: [trigger-image-tag-update]
+
+env:
+    PYTHON_VERSION: "3.11"
+
+jobs:
+    update_rasa_pro_image_tag:
+        name: Update Rasa Pro Image Tag in Docker Compose
+        runs-on: ubuntu-24.04
+
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+        - name: Set up Python ${{ env.PYTHON_VERSION }} 🐍
+          uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+          with:
+            python-version: ${{ env.PYTHON_VERSION }}
+
+        - name: Create and activate virtual environment
+          run: |
+            python -m venv .venv
+            . .venv/bin/activate
+            echo "PATH=$PATH" >> $GITHUB_ENV
+
+        - name: Install dependencies
+          run:
+            pip install -U pip
+            pip install pep440-version-utils
+
+        - name: Fetch latest version from pypi
+          id: fetch_latest_version
+          run: |
+              rasa_pro_version=$(curl -s https://pypi.org/pypi/rasa-pro/json | jq -r '.info.version')
+              echo "LATEST_RASA_PRO_VERSION=${rasa_pro_version}" >> $GITHUB_ENV
+
+        - name: Compare pypi version to the dispatched release version
+          id: compare_versions
+          if: github.event_name == 'repository_dispatch'
+          run: |
+            dispatched_version="${{ github.event.client_payload.version }}"
+            echo "DISPATCHED_RASA_PRO_VERSION=${dispatched_version}" >> $GITHUB_ENV
+            should_update=$(python scripts/compare_rasa_pro_versions.py)
+            echo "should_update=${should_update}" >> $GITHUB_OUTPUT
+
+        - name: Update Rasa Pro Image Tag
+          id: update_image_tag
+          if: (github.event_name == 'repository_dispatch' && steps.compare_versions.outputs.should_update == 'true') || github.event_name != 'repository_dispatch'
+          run: |
+            current_tag=$(grep -m 1 'image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:' docker-compose.yml | awk -F ':' '{print $3}')
+            echo "CURRENT_RASA_PRO_VERSION=${current_tag}" >> $GITHUB_ENV
+            latest_tag=$(python scripts/update_rasa_pro_image_tag.py)
+            echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+
+        - name: Check if image tag changed
+          id: check_image_tag
+          if: steps.update_image_tag.outcome == 'success'
+          run: |
+            if [ "$latest_tag" != ""No updates." ]; then
+              echo "Image tag changed from $current_tag to $latest_tag"
+              sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro::$current_tag|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$latest_tag|" docker-compose.yml
+              echo "image_tag_changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "Image tag is already up-to-date."
+              echo "image_tag_changed=false" >> $GITHUB_OUTPUT
+            fi
+
+        - name: Commit and push changes
+          id: commit_push_changes
+          if: steps.check_image_tag.outputs.image_tag_changed == 'true'
+          run: |
+            git config user.name "rasabot"
+            git config user.email "rasabot@rasa.com"
+            echo "SOURCE_BRANCH=update-rasa-pro-image-tag-to-$LATEST_RASA_PRO_VERSION" >> $GITHUB_ENV
+            git checkout -b ${{ env.SOURCE_BRANCH }}
+            git add docker-compose.yml
+            git commit -m "Update Rasa Pro image tag to ${{ env.LATEST_RASA_PRO_VERSION }}"
+            git push origin ${{ env.SOURCE_BRANCH }}
+          env:
+            GITHUB_TOKEN: ${{ secrets.RASABOT_GITHUB_TOKEN  }}
+
+        - name: Stop the workflow if no changes were made
+          if: steps.check_image_tag.outputs.image_tag_changed == 'false'
+          run: |
+            echo "No changes made to the image tag. Stopping the workflow."
+            exit 0
+
+        - name: Create pull request
+          if: steps.commit_push_changes.outcome == 'success'
+          uses: devops-infra/action-pull-request@ff118b4a7c24bac5a3c95acef59e9edd1fc37890  #v0.6.0
+          with:
+            github_token: ${{ secrets.RASABOT_GITHUB_TOKEN }}
+            source_branch: ${{ env.SOURCE_BRANCH }}
+            target_branch: "main"
+            body: "**Automated pull request for Rasa Pro image tag update.**"
+            title: Update Rasa Pro image tag to ${{ env.LATEST_RASA_PRO_VERSION }}

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -91,7 +91,7 @@ jobs:
             git commit -m "Update Rasa Pro image tag to ${{ env.LATEST_RASA_PRO_VERSION }}"
             git push origin ${{ env.SOURCE_BRANCH }}
           env:
-            GITHUB_TOKEN: ${{ secrets.RASABOT_GITHUB_TOKEN  }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
 
         - name: Stop the workflow if no changes were made
           if: steps.check_image_tag.outputs.image_tag_changed == 'false'
@@ -103,7 +103,7 @@ jobs:
           if: steps.commit_push_changes.outcome == 'success'
           uses: devops-infra/action-pull-request@ff118b4a7c24bac5a3c95acef59e9edd1fc37890  #v0.6.0
           with:
-            github_token: ${{ secrets.RASABOT_GITHUB_TOKEN }}
+            github_token: ${{ secrets.GITHUB_TOKEN }}
             source_branch: ${{ env.SOURCE_BRANCH }}
             target_branch: "main"
             body: "**Automated pull request for Rasa Pro image tag update.**"

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -18,6 +18,8 @@ jobs:
         steps:
         - name: Checkout code
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          with:
+            fetch-depth: 0
 
         - name: Set up Python ${{ env.PYTHON_VERSION }} 🐍
           uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -1,9 +1,6 @@
 name: update-rasa-pro-image-tag-version.yml
 on:
     workflow_dispatch:
-    # push required only for testing purposes
-    # to be removed before merging
-    push:
     repository_dispatch:
       types: [trigger-image-tag-update]
 
@@ -20,7 +17,7 @@ jobs:
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
-            #ref: "main" # Use main branch for the workflow
+            ref: "main" # Use main branch for the workflow
 
         - name: Set up Python ${{ env.PYTHON_VERSION }} 🐍
           uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
@@ -82,18 +79,11 @@ jobs:
           run: |
             echo "SOURCE_BRANCH=update-rasa-pro-image-tag-to-${LATEST_RASA_PRO_VERSION}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
-        - name: Set up git user
+        - name: Set up git user and checkout source branch
           if: steps.check_image_tag.outputs.image_tag_changed == 'true'
           run: |
             git config --global user.name "rasabot"
             git config --global user.email "rasabot@rasa.com"
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
-
-        - name: Checkout source branch
-          if: steps.check_image_tag.outputs.image_tag_changed == 'true'
-          run: |
-            git checkout main
             git checkout -b ${{ env.SOURCE_BRANCH }}
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -20,6 +20,7 @@ jobs:
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
+            ref: "main" # Use main branch for the workflow
 
         - name: Set up Python ${{ env.PYTHON_VERSION }} 🐍
           uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -68,7 +68,6 @@ jobs:
           run: |
             if [ "$LATEST_TAG" != "No updates." ]; then
               echo "Image tag changed from $CURRENT_RASA_PRO_VERSION to $LATEST_TAG"
-              sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$CURRENT_RASA_PRO_VERSION|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$LATEST_TAG|" docker-compose.yml
               echo "image_tag_changed=true" >> $GITHUB_OUTPUT
             else
               echo "Image tag is already up-to-date."
@@ -78,15 +77,29 @@ jobs:
         - name: Create source branch name
           if: steps.check_image_tag.outputs.image_tag_changed == 'true'
           run: |
-            echo "SOURCE_BRANCH=update-rasa-pro-image-tag-to-${LATEST_RASA_PRO_VERSION}" >> $GITHUB_ENV
+            echo "SOURCE_BRANCH=update-rasa-pro-image-tag-to-${LATEST_RASA_PRO_VERSION}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
-        - name: Commit and push changes
+        - name: Set up git user
+          if: steps.check_image_tag.outputs.image_tag_changed == 'true'
+          run: |
+            git config --global user.name "rasabot"
+            git config --global user.email "rasabot@rasa.com"
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
+
+        - name: Checkout source branch
+          if: steps.check_image_tag.outputs.image_tag_changed == 'true'
+          run: |
+            git fetch origin
+            git checkout -b ${{ env.SOURCE_BRANCH }}
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
+
+        - name: Update file, commit and push changes
           id: commit_push_changes
           if: steps.check_image_tag.outputs.image_tag_changed == 'true'
           run: |
-            git config user.name "rasabot"
-            git config user.email "rasabot@rasa.com"
-            git checkout -b ${{ env.SOURCE_BRANCH }}
+            sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$CURRENT_RASA_PRO_VERSION|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$LATEST_TAG|" docker-compose.yml
             git add docker-compose.yml
             git commit -m "Update Rasa Pro image tag to ${{ env.LATEST_RASA_PRO_VERSION }}"
             git push origin ${{ env.SOURCE_BRANCH }}

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -66,7 +66,7 @@ jobs:
           id: check_image_tag
           if: steps.update_image_tag.outcome == 'success'
           run: |
-            if [ "$latest_tag" != ""No updates." ]; then
+            if [ "$latest_tag" != "No updates." ]; then
               echo "Image tag changed from $current_tag to $latest_tag"
               sed -i "s|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$current_tag|image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:$latest_tag|" docker-compose.yml
               echo "image_tag_changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -1,4 +1,13 @@
-name: update-rasa-pro-image-tag-version.yml
+name: Update Rasa Pro Image Tag in Docker Compose file
+#    This workflow updates the Rasa Pro image tag in the `docker-compose.yml` file.
+#    It can be triggered manually or via a repository dispatch event when a Rasa Pro version is released.
+#    If triggered via repository dispatch, it compares the dispatched version with the latest version on PyPI.
+#    If the dispatched version and the latest PyPI version match, it updates the image tag in the Docker Compose file.
+#    If triggered manually, it checks directly for the latest version of Rasa Pro on PyPI.
+#    In either case, the workflow compares the latest version with the current version in the Docker Compose file.
+#    If an update is needed, it creates a new branch, commits the changes, and opens a pull request.
+#    If no update is needed, it stops the workflow without making any changes.
+
 on:
     workflow_dispatch:
     repository_dispatch:

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -32,8 +32,7 @@ jobs:
 
         - name: Install dependencies
           run:
-            pip install -U pip
-            pip install pep440-version-utils
+            python -m pip install pep440-version-utils
 
         - name: Fetch latest version from pypi
           id: fetch_latest_version

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -20,7 +20,7 @@ jobs:
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:
             fetch-depth: 0
-            ref: "main" # Use main branch for the workflow
+            #ref: "main" # Use main branch for the workflow
 
         - name: Set up Python ${{ env.PYTHON_VERSION }} 🐍
           uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
@@ -93,7 +93,9 @@ jobs:
         - name: Checkout source branch
           if: steps.check_image_tag.outputs.image_tag_changed == 'true'
           run: |
-            git fetch origin
+#            temporary checkout to test changes
+            git checkout main
+            git pull origin main
             git checkout -b ${{ env.SOURCE_BRANCH }}
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -93,9 +93,7 @@ jobs:
         - name: Checkout source branch
           if: steps.check_image_tag.outputs.image_tag_changed == 'true'
           run: |
-#            temporary checkout to test changes
             git checkout main
-            git pull origin main
             git checkout -b ${{ env.SOURCE_BRANCH }}
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -49,12 +49,16 @@ jobs:
             should_update=$(python scripts/compare_rasa_pro_versions.py)
             echo "should_update=${should_update}" >> $GITHUB_OUTPUT
 
+        - name: Extract current Rasa Pro version from docker-compose.yml
+          id: extract_current_version
+          run: |
+            current_version=$(grep -m 1 'image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:' docker-compose.yml | awk -F ':' '{print $3}')
+            echo "CURRENT_RASA_PRO_VERSION=${current_version}" >> $GITHUB_ENV
+
         - name: Update Rasa Pro Image Tag
           id: update_image_tag
           if: (github.event_name == 'repository_dispatch' && steps.compare_versions.outputs.should_update == 'true') || github.event_name != 'repository_dispatch'
           run: |
-            current_tag=$(grep -m 1 'image: europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro:' docker-compose.yml | awk -F ':' '{print $3}')
-            echo "CURRENT_RASA_PRO_VERSION=${current_tag}" >> $GITHUB_ENV
             latest_tag=$(python scripts/update_rasa_pro_image_tag.py)
             echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -75,13 +75,17 @@ jobs:
               echo "image_tag_changed=false" >> $GITHUB_OUTPUT
             fi
 
+        - name: Create source branch name
+          if: steps.check_image_tag.outputs.image_tag_changed == 'true'
+          run: |
+            echo "SOURCE_BRANCH=update-rasa-pro-image-tag-to-${LATEST_RASA_PRO_VERSION}" >> $GITHUB_ENV
+
         - name: Commit and push changes
           id: commit_push_changes
           if: steps.check_image_tag.outputs.image_tag_changed == 'true'
           run: |
             git config user.name "rasabot"
             git config user.email "rasabot@rasa.com"
-            echo "SOURCE_BRANCH=update-rasa-pro-image-tag-to-$LATEST_RASA_PRO_VERSION" >> $GITHUB_ENV
             git checkout -b ${{ env.SOURCE_BRANCH }}
             git add docker-compose.yml
             git commit -m "Update Rasa Pro image tag to ${{ env.LATEST_RASA_PRO_VERSION }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .config/
 .keras/
 .rasa/
+event.json
+.idea

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files in the repository
+*  @RasaHQ/platform-squad

--- a/scripts/compare_rasa_pro_versions.py
+++ b/scripts/compare_rasa_pro_versions.py
@@ -1,0 +1,40 @@
+import os
+from pep440_version_utils import Version, is_valid_version
+
+
+def compare_rasa_pro_versions() -> bool:
+    """
+    Compare the Pypi and the dispatched release versions for Rasa Pro.
+
+    Returns:
+        bool: True if an update is needed, False otherwise.
+    """
+
+    latest_pypi_image_version = os.getenv("LATEST_RASA_PRO_VERSION")
+    dispatched_image_version = os.getenv("DISPATCHED_RASA_PRO_VERSION")
+
+    if not latest_pypi_image_version or not dispatched_image_version:
+        print(
+            "Environment variables LATEST_RASA_PRO_VERSION and DISPATCHED_RASA_PRO_VERSION must be set."
+        )
+        return False
+
+    if not is_valid_version(latest_pypi_image_version):
+        print(f"Invalid pypi image tag: {latest_pypi_image_version}")
+        return False
+
+    if not is_valid_version(dispatched_image_version):
+        print(f"Invalid dispatched release image tag: {dispatched_image_version}")
+        return False
+
+    latest_pypi_image_tag_version = Version(latest_image_version)
+    dispatched_image_tag_version = Version(dispatched_image_version)
+
+    return latest_pypi_image_tag_version == dispatched_image_tag_version
+
+
+if __name__ == "__main__":
+    if compare_rasa_pro_versions():
+        print("true")
+    else:
+        print("false")

--- a/scripts/compare_rasa_pro_versions.py
+++ b/scripts/compare_rasa_pro_versions.py
@@ -10,27 +10,24 @@ def compare_rasa_pro_versions() -> bool:
         bool: True if an update is needed, False otherwise.
     """
 
-    latest_pypi_image_version = os.getenv("LATEST_RASA_PRO_VERSION")
-    dispatched_image_version = os.getenv("DISPATCHED_RASA_PRO_VERSION")
+    latest_pypi_version = os.getenv("LATEST_RASA_PRO_VERSION")
+    dispatched_version = os.getenv("DISPATCHED_RASA_PRO_VERSION")
 
-    if not latest_pypi_image_version or not dispatched_image_version:
+    if not latest_pypi_version or not dispatched_version:
         print(
             "Environment variables LATEST_RASA_PRO_VERSION and DISPATCHED_RASA_PRO_VERSION must be set."
         )
         return False
 
-    if not is_valid_version(latest_pypi_image_version):
-        print(f"Invalid pypi image tag: {latest_pypi_image_version}")
+    if not is_valid_version(latest_pypi_version):
+        print(f"Invalid pypi version : {latest_pypi_version}")
         return False
 
-    if not is_valid_version(dispatched_image_version):
-        print(f"Invalid dispatched release image tag: {dispatched_image_version}")
+    if not is_valid_version(dispatched_version):
+        print(f"Invalid dispatched release version: {dispatched_version}")
         return False
 
-    latest_pypi_image_tag_version = Version(latest_image_version)
-    dispatched_image_tag_version = Version(dispatched_image_version)
-
-    return latest_pypi_image_tag_version == dispatched_image_tag_version
+    return Version(latest_pypi_version) == Version(dispatched_version)
 
 
 if __name__ == "__main__":

--- a/scripts/update_rasa_pro_image_tag.py
+++ b/scripts/update_rasa_pro_image_tag.py
@@ -1,0 +1,57 @@
+import os
+from pep440_version_utils import Version, is_valid_version
+
+RASA_PRO_IMAGE_TAG = "europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro"
+DEFAULT_RESPONSE = "No updates."
+
+
+def update_rasa_pro_image_tag(
+    latest_image_tag: str,
+    current_image_tag: str,
+) -> Optional[str]:
+    """
+    Update the Rasa Pro image tag to the latest version if the provided tag is valid.
+
+    Args:
+        latest_image_tag: The latest version of the Rasa Pro image.
+        current_image_tag (str): The current image tag.
+
+    Returns:
+        str: The updated image tag if valid, otherwise the original tag.
+    """
+    if not is_valid_version(latest_image_tag):
+        print(f"Invalid new image tag: {latest_image_tag}")
+        sys.exit(1)
+
+    if not is_valid_version(current_image_tag):
+        print(f"Invalid current image tag: {current_image_tag}")
+        sys.exit(1)
+
+    latest_image_tag_version = Version(latest_image_tag)
+    current_image_tag_version = Version(current_image_tag)
+
+    if latest_image_tag_version <= current_image_tag_version:
+        print(f"Keeping current Rasa Pro image tag: {current_image_tag}")
+        return None
+
+    updated_image_tag = f"{RASA_PRO_IMAGE_TAG}:{latest_image_tag}"
+    print(f"Updating Rasa Pro image tag to: {updated_image_tag}")
+    return updated_image_tag
+
+
+if __name__ == "__main__":
+    latest_image_version = os.getenv("LATEST_RASA_PRO_VERSION")
+    current_image_version = os.getenv("CURRENT_RASA_PRO_VERSION")
+
+    if not latest_image_version or not current_image_version:
+        print(
+            "Environment variables LATEST_RASA_PRO_VERSION and CURRENT_RASA_PRO_VERSION must be set."
+        )
+        sys.exit(1)
+
+    updated_tag = update_rasa_pro_image_tag(latest_image_version, current_image_version)
+    if updated_tag:
+        print(f"{updated_tag}")
+    else:
+        print(DEFAULT_RESPONSE)
+        sys.exit(0)

--- a/scripts/update_rasa_pro_image_tag.py
+++ b/scripts/update_rasa_pro_image_tag.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from typing import Optional
 from pep440_version_utils import Version, is_valid_version
 
 RASA_PRO_IMAGE_TAG = "europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro"
@@ -34,9 +36,7 @@ def update_rasa_pro_image_tag(
         print(f"Keeping current Rasa Pro image tag: {current_image_tag}")
         return None
 
-    updated_image_tag = f"{RASA_PRO_IMAGE_TAG}:{latest_image_tag}"
-    print(f"Updating Rasa Pro image tag to: {updated_image_tag}")
-    return updated_image_tag
+    return latest_image_tag
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Automates [PF-106](https://rasahq.atlassian.net/browse/PF-106)
- Tested with manual push and the workflow succeeded in opening this PR: https://github.com/RasaHQ/developer-edition-docker-compose/pull/4
- Corresponding changes in rasa-pro repo: https://github.com/RasaHQ/rasa-private/pull/2951
- Note that the repo dispatch mechanism won't be able to be tested until the next Pro micro release on 3.13.x, after these PRs get merged

[PF-106]: https://rasahq.atlassian.net/browse/PF-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ