### PR TITLE
[PF-106] Fix repo dispatch workflow failure

### DIFF
--- a/.github/workflows/update-rasa-pro-image-tag-version.yml
+++ b/.github/workflows/update-rasa-pro-image-tag-version.yml
@@ -49,13 +49,16 @@ jobs:
               rasa_pro_version=$(curl -s https://pypi.org/pypi/rasa-pro/json | jq -r '.info.version')
               echo "LATEST_RASA_PRO_VERSION=${rasa_pro_version}" >> $GITHUB_ENV
 
+        - name: Set dispatched version env variable
+          if: github.event_name == 'repository_dispatch'
+          run: |
+            echo "DISPATCHED_RASA_PRO_VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_ENV
+
         - name: Compare pypi version to the dispatched release version
           id: compare_versions
           if: github.event_name == 'repository_dispatch'
           run: |
-            dispatched_version="${{ github.event.client_payload.version }}"
-            echo "DISPATCHED_RASA_PRO_VERSION=${dispatched_version}" >> $GITHUB_ENV
-            should_update=$(python scripts/compare_rasa_pro_versions.py)
+            should_update=$(python scripts/compare_rasa_pro_versions.py | tr -d '\n')
             echo "should_update=${should_update}" >> $GITHUB_OUTPUT
 
         - name: Extract current Rasa Pro version from docker-compose.yml


### PR DESCRIPTION
Fix [workflow failing](https://github.com/RasaHQ/developer-edition-docker-compose/actions/runs/16828047725/job/47669018359#step:8:18) when triggered by a repository dispatch event:
- separate env var setting step from running the version comparison script
- clean up breaklines from output 